### PR TITLE
test: add regression test for ingested data invisible after reopen

### DIFF
--- a/tests/ingest_tx_reopen.rs
+++ b/tests/ingest_tx_reopen.rs
@@ -38,21 +38,13 @@ fn ingested_data_visible_in_tx_after_reopen() -> fjall::Result<()> {
         );
 
         let snapshot = db.read_tx();
-        assert_eq!(
-            b"value1",
-            &*snapshot.get(&items, "key1")?.unwrap(),
-            "ingested data should be visible in read_tx after reopen"
-        );
-        assert_eq!(
-            b"value2",
-            &*snapshot.get(&items, "key2")?.unwrap(),
-            "ingested data should be visible in read_tx after reopen"
-        );
-        assert_eq!(
-            b"value3",
-            &*snapshot.get(&items, "key3")?.unwrap(),
-            "ingested data should be visible in read_tx after reopen"
-        );
+        for (key, expected) in [("key1", "value1"), ("key2", "value2"), ("key3", "value3")] {
+            assert_eq!(
+                expected.as_bytes(),
+                &*snapshot.get(&items, key)?.unwrap(),
+                "ingested data should be visible in read_tx after reopen"
+            );
+        }
     }
 
     Ok(())
@@ -88,20 +80,18 @@ fn ingested_data_visible_in_snapshot_after_reopen() -> fjall::Result<()> {
         let db = Database::builder(&folder).open()?;
         let items = db.keyspace("my_items", KeyspaceCreateOptions::default)?;
 
-        assert_eq!(b"value1", &*items.get("key1")?.unwrap());
-        assert_eq!(b"value2", &*items.get("key2")?.unwrap());
+        for (key, expected) in [("key1", "value1"), ("key2", "value2")] {
+            assert_eq!(expected.as_bytes(), &*items.get(key)?.unwrap());
+        }
 
         let snapshot = db.snapshot();
-        assert_eq!(
-            b"value1",
-            &*snapshot.get(&items, "key1")?.unwrap(),
-            "ingested data should be visible in snapshot after reopen"
-        );
-        assert_eq!(
-            b"value2",
-            &*snapshot.get(&items, "key2")?.unwrap(),
-            "ingested data should be visible in snapshot after reopen"
-        );
+        for (key, expected) in [("key1", "value1"), ("key2", "value2")] {
+            assert_eq!(
+                expected.as_bytes(),
+                &*snapshot.get(&items, key)?.unwrap(),
+                "ingested data should be visible in snapshot after reopen"
+            );
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Adds regression tests for #265: data written via `start_ingestion()` and persisted with `SyncAll` becomes invisible in `read_tx()`/`snapshot()` after reopening the database.

Two test cases:
- `ingested_data_visible_in_tx_after_reopen` — via `SingleWriterTxDatabase` + `read_tx()`
- `ingested_data_visible_in_snapshot_after_reopen` — via `Database` + `snapshot()`

## Root cause

The fix is in lsm-tree: `Table::get_highest_seqno()` must include the `global_seqno` offset so that recovery computes the correct `visible_seqno`. See fjall-rs/lsm-tree#256.

## Test plan

- [x] Tests fail without lsm-tree fix (confirmed: snapshot returns `None`)
- [x] Tests pass with lsm-tree fix (confirmed: snapshot returns correct values)
- [x] All 81 existing fjall tests still pass

Depends on: fjall-rs/lsm-tree#256
Closes #265

## Upstream

Submitted as [fjall-rs/fjall#266](https://github.com/fjall-rs/fjall/pull/266).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression tests validating data visibility after database reopening scenarios. Tests confirm that ingested data persists and remains accessible through direct access and transaction snapshots following reopen operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->