### PR TITLE
fix(docs): replace todo!() with None in builder doctest

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -175,7 +175,7 @@ impl<O: Openable> Builder<O> {
     ///     .with_compaction_filter_factories(
     ///         Arc::new(|keyspace| {
     ///             // Match on the keyspace name to assign specific compaction filters
-    ///             todo!()
+    ///             None
     ///         })
     ///     )
     ///     .open()?;


### PR DESCRIPTION
## Summary
- Replace `todo!()` with `None` in `with_compaction_filter_factories` doc example (`src/builder.rs:178`)
- `None` is a valid return for `Option<Arc<dyn Factory>>` — "no compaction filter for this keyspace"
- All 83 doc tests pass

## Test plan
- [x] `cargo test --doc` — 83/83 passed

Closes #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved code examples in builder documentation with more realistic placeholder implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->