### PR TITLE
chore: fork epoch v4.0.0 — versioning, tag convention, changelog

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,13 +20,13 @@ This is a **maintained fork** of [fjall-rs/fjall](https://github.com/fjall-rs/fj
 
 ## Dependency Policy
 
-**`lsm-tree` uses `branch = "main"` intentionally.** This fork is in active alpha development alongside `structured-world/lsm-tree`. The `branch = "main"` git dependency is correct because:
-- Both repos are under active co-development with frequent cross-repo changes
-- Dependabot tracks and updates git branch dependencies
-- Pinning to `rev` would block Dependabot and require manual bumps on every lsm-tree commit
-- Will switch to a crates.io version once upstream fjall-rs/lsm-tree#265 is released
+**`lsm-tree` is pinned to a full 40-char git `rev`.** This ensures reproducible builds for tagged fjall releases. The rev is updated when lsm-tree cuts a new release tag.
 
-**Do NOT suggest** pinning to `rev = "..."` or switching to a crates.io version for `lsm-tree`. This is a deliberate alpha-phase decision.
+**Do NOT suggest** switching to `branch = "main"` or to a crates.io version for `lsm-tree`. The tag/rev pinning is a deliberate release management decision (#24).
+
+## Release Configuration
+
+**`.release-plz.toml` uses Tera template syntax:** `tag_name = "v{{ version }}"`. The spaces inside `{{ }}` are standard Tera convention (same as Jinja2). Do NOT suggest removing them — both `{{ version }}` and `{{version}}` are equivalent in Tera.
 
 ## Rust Code Standards
 

--- a/.github/workflows/coordinode-release.yml
+++ b/.github/workflows/coordinode-release.yml
@@ -5,18 +5,22 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   release-plz:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate token (SW Release Bot)
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASER_APP_ID }}
+          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -27,5 +31,5 @@ jobs:
           command: release-pr
           config: .release-plz.toml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -5,3 +5,5 @@ publish = false
 git_release_enable = true
 # Use conventional commits for changelog
 changelog_update = true
+# Fork tags use v-prefix (v4.0.0) to distinguish from upstream (3.1.1)
+tag_name = "v{{ version }}"

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -5,6 +5,5 @@ publish = false
 git_release_enable = true
 # Use conventional commits for changelog
 changelog_update = true
-# Fork tags use v-prefix (v4.0.0) to distinguish from upstream (3.1.1).
-# Spaces in {{ version }} follow Tera/release-plz docs convention — both forms are equivalent.
+# Fork tags use v-prefix (v4.0.0) to distinguish from upstream (3.1.1)
 tag_name = "v{{ version }}"

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -5,5 +5,6 @@ publish = false
 git_release_enable = true
 # Use conventional commits for changelog
 changelog_update = true
-# Fork tags use v-prefix (v4.0.0) to distinguish from upstream (3.1.1)
+# Fork tags use v-prefix (v4.0.0) to distinguish from upstream (3.1.1).
+# Spaces in {{ version }} follow Tera/release-plz docs convention — both forms are equivalent.
 tag_name = "v{{ version }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ## 4.0.0
 
-Fork epoch release. Aligned with lsm-tree v4.0.0 (V4 disk format).
+Fork epoch release. Aligned with lsm-tree V4 disk format (based on pre-4.0.0 git revision; see Cargo.toml for exact commit).
 
 - [feat] Custom sequence number generators (`SequenceNumberGenerator` trait)
 - [feat] Snapshot (non-serializable) reads in `OptimisticTxDatabase`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+# Changelog
+
+> **Maintained fork** of [fjall-rs/fjall](https://github.com/fjall-rs/fjall) by [Structured World Foundation](https://sw.foundation) for the CoordiNode database engine.
+> Fork epoch starts at **v4.0.0** — upstream tags use no prefix (`3.1.1`), fork tags use `v`-prefix (`v4.0.0`).
+
+# 4.0.0
+
+Fork epoch release. Aligned with lsm-tree v4.0.0 (V4 disk format).
+
+- [feat] Custom sequence number generators (`SequenceNumberGenerator` trait)
+- [feat] Snapshot (non-serializable) reads in `OptimisticTxDatabase`
+- [perf] Optimized journal encoding for single-item writes (zero-alloc path)
+- [perf] `HashingWriter` for zero-alloc checksum verification in journal
+- [fix] Deadlock in `DatabaseInner::drop` under write pressure
+- [fix] Flush starvation under sustained write pressure
+- [fix] Worker thread counter underflow race on early exit
+- [fix] Journal checksum verified on raw bytes, not re-serialized data
+- [fix] Journal underflow guard before payload offset subtraction
+- [fix] Ingested data invisible after reopen
+- [fix] Worker flush recovery limited to worker #0 to avoid channel flooding
+- [refactor] Journal batch reader reuses `HashingWriter`, `HashingSink` for checksum
+- [refactor] Table-driven assertions in ingest reopen tests
+- [refactor] Transaction helpers: `mark_key_read`, bind keyspace once in `for_update`
+- [ci] CoordiNode CI with multi-OS matrix, Copilot review, upstream monitor
+- [ci] Automated changelog and releases via release-plz
+- [ci] Dependabot for cargo and actions dependencies
+- [deps] Bumped lz4_flex from 0.11 to 0.13
+
 # 3.1.0
 
 - [feat] Implemented support for compaction filters (custom logic during compactions)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 > **Maintained fork** of [fjall-rs/fjall](https://github.com/fjall-rs/fjall) by [Structured World Foundation](https://sw.foundation) for the CoordiNode database engine.
 > Fork epoch starts at **v4.0.0** — upstream tags use no prefix (`3.1.1`), fork tags use `v`-prefix (`v4.0.0`).
 
-# 4.0.0
+## 4.0.0
 
 Fork epoch release. Aligned with lsm-tree v4.0.0 (V4 disk format).
 
@@ -26,12 +26,12 @@ Fork epoch release. Aligned with lsm-tree v4.0.0 (V4 disk format).
 - [ci] Dependabot for cargo and actions dependencies
 - [deps] Bumped lz4_flex from 0.11 to 0.13
 
-# 3.1.0
+## 3.1.0
 
 - [feat] Implemented support for compaction filters (custom logic during compactions)
 - [msrv] Reduced MSRV to 1.90
 
-# 3.0.0
+## 3.0.0
 
 - [feat] Implemented new block format in `lsm-tree`
 - [feat] Bookkeep LSM-tree changes (flushes, compactions) in `Version` history

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ byteview = "~0.10.1"
 # Fork with V4 disk format + SequenceNumberGenerator trait (structured-world/lsm-tree#10).
 # TODO(#24): pin to tag = "v4.0.0" once lsm-tree release management is done.
 # Pinned to rev for reproducible builds until tag exists.
-lsm-tree = { git = "https://github.com/structured-world/lsm-tree.git", rev = "c03a443", default-features = false, features = [] }
+lsm-tree = { git = "https://github.com/structured-world/lsm-tree.git", rev = "c03a443515ce90b70d40200d679c77a170209d83", default-features = false, features = [] }
 log = "0.4.27"
 tempfile = "3.20.0"
 dashmap = "6.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,12 +2,12 @@
 name = "fjall"
 description = "Log-structured, embeddable key-value storage engine"
 license = "MIT OR Apache-2.0"
-version = "3.1.1"
+version = "4.0.0"
 edition = "2021"
 rust-version = "1.90.0"
 readme = "README.md"
 include = ["src/**/*", "LICENSE-APACHE", "LICENSE-MIT", "README.md"]
-repository = "https://github.com/fjall-rs/fjall"
+repository = "https://github.com/structured-world/fjall"
 homepage = "https://github.com/fjall-rs/fjall"
 keywords = ["database", "key-value", "lsm", "rocksdb", "leveldb"]
 categories = ["data-structures", "database-implementations", "algorithms"]
@@ -26,9 +26,9 @@ __internal_whitebox = []
 [dependencies]
 byteorder = { package = "byteorder-lite", version = "0.1.0" }
 byteview = "~0.10.1"
-# Fork with SequenceNumberGenerator trait (structured-world/lsm-tree#10).
+# Fork with V4 disk format + SequenceNumberGenerator trait (structured-world/lsm-tree#10).
+# TODO(#24): pin to tag = "v4.0.0" once lsm-tree release management is done.
 # branch=main: active development, Dependabot tracks updates.
-# Switch to crates.io once fjall-rs/lsm-tree#265 is released.
 lsm-tree = { git = "https://github.com/structured-world/lsm-tree.git", branch = "main", default-features = false, features = [] }
 log = "0.4.27"
 tempfile = "3.20.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = "1.90.0"
 readme = "README.md"
 include = ["src/**/*", "LICENSE-APACHE", "LICENSE-MIT", "README.md"]
 repository = "https://github.com/structured-world/fjall"
+# homepage points to upstream — docs.rs and project docs live there
 homepage = "https://github.com/fjall-rs/fjall"
 keywords = ["database", "key-value", "lsm", "rocksdb", "leveldb"]
 categories = ["data-structures", "database-implementations", "algorithms"]
@@ -28,8 +29,8 @@ byteorder = { package = "byteorder-lite", version = "0.1.0" }
 byteview = "~0.10.1"
 # Fork with V4 disk format + SequenceNumberGenerator trait (structured-world/lsm-tree#10).
 # TODO(#24): pin to tag = "v4.0.0" once lsm-tree release management is done.
-# branch=main: active development, Dependabot tracks updates.
-lsm-tree = { git = "https://github.com/structured-world/lsm-tree.git", branch = "main", default-features = false, features = [] }
+# Pinned to rev for reproducible builds until tag exists.
+lsm-tree = { git = "https://github.com/structured-world/lsm-tree.git", rev = "c03a443", default-features = false, features = [] }
 log = "0.4.27"
 tempfile = "3.20.0"
 dashmap = "6.1.0"


### PR DESCRIPTION
## Summary
- Bump version 3.1.1 → 4.0.0 (fork epoch, aligned with lsm-tree V4 disk format)
- Add `tag_name = "v{{ version }}"` to `.release-plz.toml` — fork tags use `v`-prefix
- Pin lsm-tree to full 40-char git rev for reproducible builds
- Update `repository` URL to structured-world fork
- Add fork provenance header and 4.0.0 section to CHANGELOG.md
- Switch release workflow to SW Release Bot app token (replaces GITHUB_TOKEN)
- Update Copilot review instructions: rev pinning policy, Tera template convention

## Blocked items (follow-up after lsm-tree v4.0.0 release)
- Pin lsm-tree dependency to `tag = "v4.0.0"` (currently pinned to rev)
- CoordiNode pin to fjall `tag = "v4.0.0"`

Closes #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Version 4.0.0 release with new sequence number generator trait and enhanced snapshot functionality.
  * Zero-allocation journal encoding and improved checksum verification.

* **Bug Fixes**
  * Fixed multiple deadlock, underflow, flush, and starvation issues.
  * Resolved visibility issues after reopening database.

* **Chores**
  * Updated repository metadata and homepage references.
  * Enhanced release automation and tag naming configuration.
  * Updated dependency versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->