### PR TITLE
style(journal): add target-gated cast_possible_truncation annotations to decode_item_payload

### DIFF
--- a/src/journal/entry.rs
+++ b/src/journal/entry.rs
@@ -206,6 +206,12 @@ impl From<Tag> for u8 {
 
 /// Decodes item payload fields (everything after the tag byte) from a reader.
 /// Shared between `Tag::Item` and `Tag::SingleItem` decoding.
+///
+/// The `u32 as usize` casts use `#[allow(clippy::cast_possible_truncation)]`
+/// (not `#[expect]`) because the lint only fires when usize < 32 bits — on
+/// 64-bit hosts the cast is lossless and `expect` would be unfulfilled.
+/// Per-statement `#[allow]` is kept (rather than a helper) to match the
+/// symmetrical pattern in [`serialize_item_payload`].
 fn decode_item_payload<R: Read>(
     reader: &mut R,
 ) -> Result<

--- a/src/journal/entry.rs
+++ b/src/journal/entry.rs
@@ -207,11 +207,10 @@ impl From<Tag> for u8 {
 /// Decodes item payload fields (everything after the tag byte) from a reader.
 /// Shared between `Tag::Item` and `Tag::SingleItem` decoding.
 ///
-/// The `u32 as usize` casts use `#[allow(clippy::cast_possible_truncation)]`
-/// (not `#[expect]`) because the lint only fires when usize < 32 bits — on
-/// 64-bit hosts the cast is lossless and `expect` would be unfulfilled.
-/// Per-statement `#[allow]` is kept (rather than a helper) to match the
-/// symmetrical pattern in [`serialize_item_payload`].
+/// The `u32 as usize` casts use target-gated `#[expect(clippy::cast_possible_truncation)]`
+/// to enforce the expectation only on 16-bit targets where truncation is possible,
+/// without triggering `unfulfilled_lint_expectations` on 32/64-bit hosts.
+/// Per-statement attributes are kept for symmetry with [`serialize_item_payload`].
 fn decode_item_payload<R: Read>(
     reader: &mut R,
 ) -> Result<
@@ -241,18 +240,24 @@ fn decode_item_payload<R: Read>(
     let value = match compression {
         CompressionType::None => {
             debug_assert_eq!(value_len, on_disk_value_len);
-            #[allow(
-                clippy::cast_possible_truncation,
-                reason = "u32 → usize: lossless on 32-bit+, but may truncate on 16-bit"
+            #[cfg_attr(
+                target_pointer_width = "16",
+                expect(
+                    clippy::cast_possible_truncation,
+                    reason = "u32 → usize may truncate on 16-bit usize targets"
+                )
             )]
             Slice::from_reader(reader, on_disk_value_len as usize)?
         }
 
         #[cfg(feature = "lz4")]
         CompressionType::Lz4 => {
-            #[allow(
-                clippy::cast_possible_truncation,
-                reason = "u32 → usize: lossless on 32-bit+, but may truncate on 16-bit"
+            #[cfg_attr(
+                target_pointer_width = "16",
+                expect(
+                    clippy::cast_possible_truncation,
+                    reason = "u32 → usize may truncate on 16-bit usize targets"
+                )
             )]
             let compressed_value = Slice::from_reader(reader, on_disk_value_len as usize)?;
 
@@ -260,9 +265,12 @@ fn decode_item_payload<R: Read>(
                 unsafe_code,
                 reason = "unzeroed buffer for LZ4 decompression performance"
             )]
-            #[allow(
-                clippy::cast_possible_truncation,
-                reason = "u32 → usize: lossless on 32-bit+, but may truncate on 16-bit"
+            #[cfg_attr(
+                target_pointer_width = "16",
+                expect(
+                    clippy::cast_possible_truncation,
+                    reason = "u32 → usize may truncate on 16-bit usize targets"
+                )
             )]
             // SAFETY: decompress_into writes exactly value_len bytes on success
             // (validated by the size check below). The buffer is fully initialized

--- a/src/journal/entry.rs
+++ b/src/journal/entry.rs
@@ -235,16 +235,28 @@ fn decode_item_payload<R: Read>(
     let value = match compression {
         CompressionType::None => {
             debug_assert_eq!(value_len, on_disk_value_len);
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "u32 → usize: lossless on 32-bit+, but may truncate on 16-bit"
+            )]
             Slice::from_reader(reader, on_disk_value_len as usize)?
         }
 
         #[cfg(feature = "lz4")]
         CompressionType::Lz4 => {
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "u32 → usize: lossless on 32-bit+, but may truncate on 16-bit"
+            )]
             let compressed_value = Slice::from_reader(reader, on_disk_value_len as usize)?;
 
             #[expect(
                 unsafe_code,
                 reason = "unzeroed buffer for LZ4 decompression performance"
+            )]
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "u32 → usize: lossless on 32-bit+, but may truncate on 16-bit"
             )]
             // SAFETY: decompress_into writes exactly value_len bytes on success
             // (validated by the size check below). The buffer is fully initialized


### PR DESCRIPTION
## Summary
- Add `#[cfg_attr(target_pointer_width = "16", expect(clippy::cast_possible_truncation))]` to three `as usize` casts (`u32 → usize`) in `decode_item_payload` for consistency with `serialize_item_payload`
- Target-gated `expect` fires only on 16-bit targets where truncation is actually possible, avoiding `unfulfilled_lint_expectations` on 32/64-bit hosts
- Per-statement attributes kept for symmetry with `serialize_item_payload`

## Test Plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-features` — 0 warnings
- [x] `cargo test --all-features` — 83 passed
- [x] `cargo build --all-features` — ok

Closes #11