### PR TITLE
fix: resolve 50 clippy errors (indexing_slicing, unwrap_used, expect_used)

### DIFF
--- a/src/journal/entry.rs
+++ b/src/journal/entry.rs
@@ -298,6 +298,7 @@ impl Entry {
     #[cfg(test)]
     pub fn encode_into_vec(&self) -> Vec<u8> {
         let mut buf = Vec::new();
+        #[allow(clippy::expect_used)]
         self.encode_into(&mut buf).expect("should encode");
         buf
     }

--- a/src/journal/test.rs
+++ b/src/journal/test.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use super::*;
 use crate::batch::item::Item as BatchItem;
 use crate::file::MAGIC_BYTES;

--- a/src/tx/optimistic/write_tx.rs
+++ b/src/tx/optimistic/write_tx.rs
@@ -1169,6 +1169,7 @@ mod tests {
     }
 
     #[test]
+    #[expect(clippy::unwrap_used)]
     fn tx_snapshot_first_last_size_of() -> Result<(), Box<dyn std::error::Error>> {
         let env = setup()?;
 


### PR DESCRIPTION
## Summary
- Suppress `clippy::indexing_slicing` at module level in `src/journal/test.rs` (47 test assertion errors)
- Allow `clippy::expect_used` in test-only `encode_into_vec` helper (`src/journal/entry.rs`)
- Expect `clippy::unwrap_used` in `tx_snapshot_first_last_size_of` test (`src/tx/optimistic/write_tx.rs`)

All 50 errors are in test code where panicking on unexpected state is the correct behavior.

## Test plan
- [x] `cargo clippy --all-targets` — zero errors
- [x] `cargo test --lib` — 91 passed
- [x] `cargo test` (all targets) — 86 doc/integration tests passed

Closes #35